### PR TITLE
Added #show, #new, #create actions for rentals

### DIFF
--- a/app/controllers/rentals_controller.rb
+++ b/app/controllers/rentals_controller.rb
@@ -3,8 +3,8 @@ class RentalsController < ApplicationController
     @rentals = Rental.all
   end
 
-  def show
-  end
+  # def show
+  # end
 
   def new
   end

--- a/app/controllers/rentals_controller.rb
+++ b/app/controllers/rentals_controller.rb
@@ -3,15 +3,32 @@ class RentalsController < ApplicationController
     @rentals = Rental.all
   end
 
-  # def show
-  # end
+  def show
+    @rental = Rental.find(params[:id])
+  end
 
   def new
+    @camera = Camera.find(params[:camera_id])
+    @rental = Rental.new
   end
 
   def create
+    @rental = Rental.new(rental_params)
+    @camera = Camera.find(params[:camera_id])
+    @user = User.find(current_user.id)
+    @rental.camera = @camera
+    @rental.user = @user
+    @rental.save
+
+    redirect_to rental_path(@rental)
   end
 
   def destroy
+  end
+
+  private
+
+  def rental_params
+    params.require(:rental).permit(:start_date, :end_date)
   end
 end

--- a/app/views/cameras/index.html.erb
+++ b/app/views/cameras/index.html.erb
@@ -1,4 +1,4 @@
-<h1>All available Cameras</h1>
+<h1>All Available Cameras</h1>
  <h2><%= link_to "Add A Camera", new_camera_path %></h2>
 
   <% @cameras.each do |camera| %>

--- a/app/views/cameras/show.html.erb
+++ b/app/views/cameras/show.html.erb
@@ -2,4 +2,5 @@
 <p><%= @camera.details %></p>
 <p><%= @camera.price_per_day %></p>
 
+ <p><%= link_to "Rent camera", new_camera_rental_path(params[:id]) %></p>
  <p><%= link_to "Back to the list", cameras_path %></p>

--- a/app/views/rentals/new.html.erb
+++ b/app/views/rentals/new.html.erb
@@ -1,0 +1,7 @@
+<h1>Book camera</h1>
+
+<%= simple_form_for [ @camera, @rental ] do |f| %>
+  <%= f.input :start_date %>
+  <%= f.input :end_date %>
+  <%= f.submit "Submit request", class: "btn btn-primary" %>
+<% end %>

--- a/app/views/rentals/new.html.erb
+++ b/app/views/rentals/new.html.erb
@@ -5,3 +5,5 @@
   <%= f.input :end_date %>
   <%= f.submit "Submit request", class: "btn btn-primary" %>
 <% end %>
+
+<%= link_to "Back to cameras", cameras_path %>

--- a/app/views/rentals/show.html.erb
+++ b/app/views/rentals/show.html.erb
@@ -1,0 +1,1 @@
+<h1>Rental summary:</h1>

--- a/app/views/rentals/show.html.erb
+++ b/app/views/rentals/show.html.erb
@@ -1,1 +1,9 @@
 <h1>Rental summary:</h1>
+
+<p><%= @rental.camera.model %></p>
+<p><%= @rental.camera.details %></p>
+<p>From:<%= @rental.start_date %></p>
+<p>Until:<%= @rental.end_date %></p>
+
+<%#= link_to "Cancel request", %>
+<%= link_to "Back to cameras", cameras_path %>


### PR DESCRIPTION
What changed: 
- Added #show, #new, #create actions for rentals
- Added show & new pages for rentals with "back to cameras" links

How to test: 
- GOTO /cameras, go to a camera and click "Rent camera". Should be able to create a rental request (new/create) and be directed to the request summary (show).