### PR TITLE
Fixed welcome msg alignment

### DIFF
--- a/app/assets/stylesheets/components/_navbar.scss
+++ b/app/assets/stylesheets/components/_navbar.scss
@@ -16,3 +16,8 @@
 .logo {
   margin-right: 3px;
 }
+
+.welcome-msg {
+  padding: 0.25rem 1rem;
+  text-align: inherit;
+}

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -20,7 +20,7 @@
           <li class="nav-item dropdown">
             <%= image_tag "https://e7.pngegg.com/pngimages/416/62/png-clipart-anonymous-person-login-google-account-computer-icons-user-activity-miscellaneous-computer.png", class: "avatar dropdown-toggle", id: "navbarDropdown", data: { bs_toggle: "dropdown" }, 'aria-haspopup': true, 'aria-expanded': false %>
             <div class="dropdown-menu dropdown-menu-end" aria-labelledby="navbarDropdown">
-              <p>Welcome <%= current_user.first_name %>!</p>
+              <p class="welcome-msg">Welcome <%= current_user.first_name %>!</p>
               <%= link_to "Add a camera", new_camera_path, class: "dropdown-item" %>
               <%= link_to "Rent a camera", cameras_path , class: "dropdown-item" %>
               <%= link_to "My listings", my_cameras_path, class: "dropdown-item" %>


### PR DESCRIPTION
What changed:
- Fixed welcome msg alignment (to be same as the dropdown items)

How to test: 
- GOTO any page-> click on dropdown menu-> the welcome msg should be aligned like so:
<img width="208" alt="Screen Shot 2022-05-19 at 5 07 24 PM" src="https://user-images.githubusercontent.com/100733281/169404860-2d711ace-e2d6-4f9e-b282-4086bbf6a8d8.png">


