### PR TITLE
Add rental to camera show page

### DIFF
--- a/app/controllers/cameras_controller.rb
+++ b/app/controllers/cameras_controller.rb
@@ -20,6 +20,7 @@ class CamerasController < ApplicationController
 
   def show
     @camera = Camera.find(params[:id])
+    @rental = Rental.new
   end
 
   def edit

--- a/app/controllers/rentals_controller.rb
+++ b/app/controllers/rentals_controller.rb
@@ -8,10 +8,10 @@ class RentalsController < ApplicationController
     @camera = @rental.camera
   end
 
-  def new
-    @camera = Camera.find(params[:camera_id])
-    @rental = Rental.new
-  end
+  # def new
+  #   @camera = Camera.find(params[:camera_id])
+  #   @rental = Rental.new
+  # end
 
   def create
     @rental = Rental.new(rental_params)
@@ -22,7 +22,7 @@ class RentalsController < ApplicationController
     if @rental.save
       redirect_to rental_path(@rental)
     else
-      render :new
+      render 'cameras/show'
     end
   end
 

--- a/app/views/cameras/show.html.erb
+++ b/app/views/cameras/show.html.erb
@@ -19,11 +19,11 @@
 
   <% if current_user != @camera.user %>
 
-    <h2 class="text-center mt-3 mb-5">Book camera</h2>
+    <h3 class="text-center my-3">Book camera</h3>
 
     <div class="d-flex justify-content-center w-50 mx-auto">
 
-      <div class="form-wrapper" style="width: 400px" data-controller="flatpickr">
+      <div class="form-wrapper" style="width: 500px" data-controller="flatpickr">
         <%= simple_form_for [ @camera, @rental ] do |f| %>
           <%= f.input :start_date, as: :string, input_html: {id: "start_datepicker"} %>
           <%= f.input :end_date, as: :string, input_html: {id: "end_datepicker"} %>

--- a/app/views/cameras/show.html.erb
+++ b/app/views/cameras/show.html.erb
@@ -12,11 +12,37 @@
               <p><span class="bold-text-card-details">Price per day: </span><%= @camera.price_per_day %></p>
               <p><span class="bold-text-card-details">Address: </span><%= @camera.address %></p>
             <%# </div> %>
-              <% if current_user != @camera.user %>
-                <p class="update-edit-links"><%= link_to "RENT CAMERA", new_camera_rental_path(params[:id]) %></p>
-              <% end %>
               <p class="update-edit-links"><%= link_to "BACK TO LIST", cameras_path %></p>
           </div>
     </div>
   </div>
+
+  <% if current_user != @camera.user %>
+
+    <h2 class="text-center mt-3 mb-5">Book camera</h2>
+
+    <div class="d-flex justify-content-center w-50 mx-auto">
+
+      <div class="form-wrapper" style="width: 400px" data-controller="flatpickr">
+        <%= simple_form_for [ @camera, @rental ] do |f| %>
+          <%= f.input :start_date, as: :string, input_html: {id: "start_datepicker"} %>
+          <%= f.input :end_date, as: :string, input_html: {id: "end_datepicker"} %>
+          <%= f.submit "Submit request", class: "btn btn-primary" %>
+        <% end %>
+      </div>
+
+      <!-- To display the calculated total price -->
+      <div class="price-container">
+        <p>Daily price: $
+          <span id="daily-price">
+            <%= @camera.price_per_day %>
+          </span>
+          CAD
+        </p>
+        <p id="num-days"></p>
+        <p id="total-price"></p>
+      </div>
+    </div>
+  <% end %>
+
 </div>

--- a/app/views/rentals/show.html.erb
+++ b/app/views/rentals/show.html.erb
@@ -14,7 +14,7 @@
             <p><%= @rental.camera.details %></p>
           <h3> Dates </h3>
             <p>From: <strong><%= @rental.start_date %></strong></p>
-            <p>Until: <strong><%= @rental.start_date %></strong></p>
+            <p>Until: <strong><%= @rental.end_date %></strong></p>
         </div>
         <div class="col-6  d-flex flex-column justify-content-center align-items-center ">
           <h3>Status of the Request</h3>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
   root to: 'pages#home'
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   resources :cameras do
-    resources :rentals, only: [ :new, :create ]
+    resources :rentals, only: :create
   end
 
   get 'my_cameras', to: 'cameras#my_cameras'


### PR DESCRIPTION
What changed:
- Added rental form to camera's show page
- Edited style of form to be the same width of camera card

How to test:
GOTO: /cameras and pick a camera
- If it's YOUR camera you should not see the form to rent it. If it's not your camera, you should see the form and be able to rent it. 
- When you submit, should go to the rental summary page