### PR TITLE
Added total price on rental summary page

### DIFF
--- a/app/views/rentals/show.html.erb
+++ b/app/views/rentals/show.html.erb
@@ -8,13 +8,15 @@
   <div class="row justify-content-center m-3 ">
     <div class="col-10 ">
       <div class="row justify-content-start border-solid  ">
-        <div class="col-6  ">
+        <div class="col-6">
           <h2>Rental Details</h2>
             <p><%= @rental.camera.model %></p>
             <p><%= @rental.camera.details %></p>
           <h3> Dates </h3>
             <p>From: <strong><%= @rental.start_date %></strong></p>
             <p>Until: <strong><%= @rental.end_date %></strong></p>
+          <h3> Total Price </h3>
+            <p> $<%= (@rental.end_date - @rental.start_date).to_i * @rental.camera.price_per_day %> CAD</p>
         </div>
         <div class="col-6  d-flex flex-column justify-content-center align-items-center ">
           <h3>Status of the Request</h3>


### PR DESCRIPTION
What changed:
- Added total price on rental summary page

How to test:
GOTO /rentals, click on a rental and you should see the total price displayed as below:

<img width="1164" alt="Screen Shot 2022-05-20 at 2 38 40 PM" src="https://user-images.githubusercontent.com/100733281/169591848-aa56bc49-9248-4b25-8fad-506b2d74c289.png">

